### PR TITLE
Remove border on hovered <button> elements in the docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,13 +16,17 @@
 
     <title>shareon</title>
 
+    <link rel="stylesheet" href="https://igoradamenko.github.io/awsm.css/css/awsm.min.css">
+
     <style>
         .shareon > a:hover {
             color: #fff;
         }
-    </style>
 
-    <link rel="stylesheet" href="https://igoradamenko.github.io/awsm.css/css/awsm.min.css">
+        button:not([disabled]):hover {
+            border: none;
+        }
+    </style>
 
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">


### PR DESCRIPTION
From the semantic `awsm.css`, hovered buttons get a one-pixel-wide black border when they're hovered. In the first example of the [Usage](https://shareon.js.org/#usage) section of the docs, this meant that hovering them would cause them to wiggle around slightly. 

Given that this is a part of a separate library, not shareon itself, I figured that, while the wiggling around was almost certainly not intentional, neither was the black border. So, instead of keeping the border and removing the wiggling, this PR gets rid of both. 

All this does is move the in-head `<style>` tag to underneath the `awsm.css` inclusion and add a copy of the same selector that caused the issue with a `border: none`.  Given there aren't any buttons elsewhere on the page, this should be fine. 😄 